### PR TITLE
fix: The format of the usage scope is incorrect.

### DIFF
--- a/core/OAuth2_Handler.php
+++ b/core/OAuth2_Handler.php
@@ -185,8 +185,13 @@ class OAuth2_Handler extends Base {
 
 		$config = $this->get_provider_config( $provider_key );
 
+		$scope = $config['scopes'];
+		if ( \is_array( $scope ) ) {
+			$scope = \implode( ' ', $scope );
+		}
+
 		$options = array(
-			'scope' => $config['scopes'],
+			'scope' => $scope,
 		);
 
 		if ( 'gmail' === $provider_key ) {


### PR DESCRIPTION
This pull request has fixed the following issues:

When logging in with the organization account, the following problem occurred:

```
AADSTS650053: The application 'My App Name' asked for scope 'SMTP.Send,offline_access' that doesn't exist on the resource '00000003-0000-0000-c000-000000000000'. Contact the app vendor.
```

According to the research, [existing discussions within the community](https://techcommunity.microsoft.com/discussions/appsonazure/microsoft-entra-id-app-not-accessible-to-other-organisations/4258711) and my local repair verification, The problem is identified as being caused by using commas to separate the list when providing the range instead of spaces (in the current implementation, the entire array was directly submitted, resulting in it being formatted with commas as separators). In other cases, this error is ignored. However, when using the organization account, the requirements will become stricter.

It should be noted that, due to:
- The Auth 2.0 standard [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3) defines the scope in a list separated by spaces.
- The [Microsoft identity platform v2.0](https://learn.microsoft.com/entra/identity-platform/v2-oauth2-auth-code-flow) documentation uses spaces to separate the scope parameter.
- The [Google OAuth 2.0 docs](https://developers.google.com/identity/protocols/oauth2/web-server#httprest) also use spaces to separate the requested scope.

I directly modified the generation logic of the "scope" in this fix branch to "convert it into a string separated by spaces".

Ref: #43