### PR TITLE
Provide a query-parameter-free redirect URL for the new Microsoft OAuth2 standard

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,5 @@
 === SMTP for Contact Form 7 ===
-Contributors: codekraft, gardenboi
+Contributors: codekraft, gardenboi, MemoryShadow
 Tags: smtp, mail, wp mail, mail template, contact form 7, oauth2, gmail, office365
 Requires PHP: 7.1
 Requires at least: 5.5

--- a/backend/Settings_Form.php
+++ b/backend/Settings_Form.php
@@ -447,21 +447,28 @@ class Settings_Form {
 	 * Prints the OAuth2 Redirect URI (read-only) for the user to copy.
 	 */
 	public function cf7_smtp_print_oauth2_redirect_uri_callback() {
-		$redirect_uri = \admin_url( 'admin.php' );
-		// Ensure the redirect URI matches exactly what the OAuth2 provider expects
-		$redirect_uri = \add_query_arg(
+		$admin_callback = \add_query_arg(
 			array(
 				'page'            => 'cf7-smtp',
 				'oauth2_callback' => 1,
 			),
-			$redirect_uri
+			\admin_url( 'admin.php' )
 		);
+		$rest_callback  = \rest_url( 'cf7-smtp/v1/oauth2/callback' );
+
+		$current_provider = ! empty( $this->options['oauth2_provider'] ) ? $this->options['oauth2_provider'] : 'gmail';
+		$initial_callback = 'office365' === $current_provider ? $rest_callback : $admin_callback;
 
 		\printf(
-			'<code style="user-select: all; background: #f0f0f1; padding: 5px 10px; display: block; margin-bottom: 5px;">%s</code>
-			<p class="description">%s</p>',
-			\esc_html( $redirect_uri ),
-			\esc_html__( 'Copy this URL and add it to your "Authorized Redirect URIs" in your Google Cloud Console or OAuth2 Provider settings.', 'cf7-smtp' )
+			'<code id="cf7_smtp_oauth2_redirect_uri"
+				   data-gmail-redirect-uri="%1$s"
+				   data-office365-redirect-uri="%2$s"
+				   style="user-select: all; background: #f0f0f1; padding: 5px 10px; display: block; margin-bottom: 5px;">%4$s</code>
+			<p class="description">%3$s</p>',
+			\esc_attr( $admin_callback ),
+			\esc_attr( $rest_callback ),
+			\esc_html__( 'Copy the Redirect URI and add it to your OAuth provider settings. This API-based endpoint is designed for maximum compatibility and reliability.', 'cf7-smtp' ),
+			\esc_html( $initial_callback )
 		);
 	}
 

--- a/backend/Settings_Form.php
+++ b/backend/Settings_Form.php
@@ -467,7 +467,7 @@ class Settings_Form {
 			<p class="description">%3$s</p>',
 			\esc_attr( $admin_callback ),
 			\esc_attr( $rest_callback ),
-			\esc_html__( 'Copy the Redirect URI and add it to your OAuth provider settings. This API-based endpoint is designed for maximum compatibility and reliability.', 'cf7-smtp' ),
+			\esc_html__( 'Copy this URL and add it to your "Authorized Redirect URIs" in your Google Cloud Console or OAuth2 Provider settings.', 'cf7-smtp' ),
 			\esc_html( $initial_callback )
 		);
 	}

--- a/backend/Settings_Page.php
+++ b/backend/Settings_Page.php
@@ -109,13 +109,19 @@ class Settings_Page extends Base {
 	 * Check for OAuth2 callback and handle token exchange.
 	 */
 	public function check_oauth2_callback() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- OAuth2 state param used for verification
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- External OAuth callback, state is verified via transients.
 		if ( ! isset( $_GET['page'] ) || 'cf7-smtp' !== $_GET['page'] || ! isset( $_GET['oauth2_callback'] ) ) {
 			return;
 		}
 
 		$handler = new \cf7_smtp\Core\OAuth2_Handler();
-		$state   = ( isset( $_GET['state'] ) && \is_scalar( $_GET['state'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['state'] ) ) : '';
+
+		// Extract all relevant parameters from the callback.
+		$state      = ( isset( $_GET['state'] ) && \is_scalar( $_GET['state'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['state'] ) ) : '';
+		$code       = ( isset( $_GET['code'] ) && \is_scalar( $_GET['code'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['code'] ) ) : '';
+		$error      = ( isset( $_GET['error'] ) && \is_scalar( $_GET['error'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['error'] ) ) : '';
+		$error_desc = ( isset( $_GET['error_description'] ) && \is_scalar( $_GET['error_description'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['error_description'] ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Verify state for OAuth2 callback using transient-based validation.
 		if ( empty( $state ) || ! $handler->validate_state( $state, false ) ) {
@@ -126,14 +132,9 @@ class Settings_Page extends Base {
 		}
 
 		// Handle OAuth2 error responses (e.g. user cancelled the Microsoft consent screen).
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- state/transient already verified above
-		if ( isset( $_GET['error'] ) || isset( $_GET['error_description'] ) ) {
-			$error_code = ( isset( $_GET['error'] ) && \is_scalar( $_GET['error'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['error'] ) ) : 'unknown_error';
-			$error_desc = ( isset( $_GET['error_description'] ) && \is_scalar( $_GET['error_description'] ) )
-				? \sanitize_text_field( \wp_unslash( $_GET['error_description'] ) )
-				: '';
-
-			$message = \sprintf(
+		if ( ! empty( $error ) || ! empty( $error_desc ) ) {
+			$error_code = ! empty( $error ) ? $error : 'unknown_error';
+			$message    = \sprintf(
 				/* translators: 1: OAuth2 error code  2: human-readable error description */
 				__( 'OAuth2 authorization failed: %1$s. %2$s', 'cf7-smtp' ),
 				$error_code,
@@ -146,7 +147,6 @@ class Settings_Page extends Base {
 			exit;
 		}
 
-		$code = ( isset( $_GET['code'] ) && \is_scalar( $_GET['code'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['code'] ) ) : '';
 		if ( empty( $code ) ) {
 			cf7_smtp_log( 'OAuth2 callback: Missing or invalid authorization code' );
 			\set_transient( 'cf7_smtp_oauth2_error', \__( 'Missing or invalid authorization code. Please try again.', 'cf7-smtp' ), 60 );

--- a/backend/Settings_Page.php
+++ b/backend/Settings_Page.php
@@ -114,10 +114,32 @@ class Settings_Page extends Base {
 			return;
 		}
 
-		// Verify nonce for OAuth2 callback
+		// Verify nonce for OAuth2 callback.
 		if ( ! isset( $_GET['state'] ) || ! \wp_verify_nonce( \sanitize_key( $_GET['state'] ), 'cf7-smtp-oauth2' ) ) {
 			cf7_smtp_log( 'OAuth2 callback: Invalid nonce or missing state parameter' );
 			return;
+		}
+
+		// Handle OAuth2 error responses (e.g. user cancelled the Microsoft consent screen).
+		// This check MUST come after state verification to prevent forged error notices.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- state/nonce already verified above
+		if ( isset( $_GET['error'] ) ) {
+			$error_code = \sanitize_text_field( \wp_unslash( $_GET['error'] ) );
+			$error_desc = isset( $_GET['error_description'] )
+				? \sanitize_text_field( \wp_unslash( $_GET['error_description'] ) )
+				: '';
+
+			$message = \sprintf(
+				/* translators: 1: OAuth2 error code  2: human-readable error description */
+				__( 'OAuth2 authorization failed: %1$s. %2$s', 'cf7-smtp' ),
+				$error_code,
+				$error_desc
+			);
+			cf7_smtp_log( 'OAuth2 callback error: ' . $error_code . ' - ' . $error_desc );
+			\set_transient( 'cf7_smtp_oauth2_error', $message, 60 );
+
+			\wp_safe_redirect( \admin_url( 'admin.php?page=cf7-smtp' ) );
+			exit;
 		}
 
 		if ( ! isset( $_GET['code'] ) ) {

--- a/backend/Settings_Page.php
+++ b/backend/Settings_Page.php
@@ -115,19 +115,21 @@ class Settings_Page extends Base {
 		}
 
 		$handler = new \cf7_smtp\Core\OAuth2_Handler();
-		$state   = isset( $_GET['state'] ) ? \sanitize_text_field( \wp_unslash( $_GET['state'] ) ) : '';
+		$state   = ( isset( $_GET['state'] ) && \is_scalar( $_GET['state'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['state'] ) ) : '';
 
 		// Verify state for OAuth2 callback using transient-based validation.
 		if ( empty( $state ) || ! $handler->validate_state( $state, false ) ) {
 			cf7_smtp_log( 'OAuth2 callback: Invalid state parameter or missing state' );
-			return;
+			\set_transient( 'cf7_smtp_oauth2_error', \__( 'Invalid or expired OAuth2 state. Please try again.', 'cf7-smtp' ), 60 );
+			\wp_safe_redirect( \admin_url( 'admin.php?page=cf7-smtp' ) );
+			exit;
 		}
 
 		// Handle OAuth2 error responses (e.g. user cancelled the Microsoft consent screen).
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- state/transient already verified above
 		if ( isset( $_GET['error'] ) || isset( $_GET['error_description'] ) ) {
-			$error_code = isset( $_GET['error'] ) ? \sanitize_text_field( \wp_unslash( $_GET['error'] ) ) : 'unknown_error';
-			$error_desc = isset( $_GET['error_description'] )
+			$error_code = ( isset( $_GET['error'] ) && \is_scalar( $_GET['error'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['error'] ) ) : 'unknown_error';
+			$error_desc = ( isset( $_GET['error_description'] ) && \is_scalar( $_GET['error_description'] ) )
 				? \sanitize_text_field( \wp_unslash( $_GET['error_description'] ) )
 				: '';
 
@@ -144,14 +146,17 @@ class Settings_Page extends Base {
 			exit;
 		}
 
-		if ( ! isset( $_GET['code'] ) ) {
-			cf7_smtp_log( 'OAuth2 callback: Missing authorization code' );
-			return;
+		$code = ( isset( $_GET['code'] ) && \is_scalar( $_GET['code'] ) ) ? \sanitize_text_field( \wp_unslash( $_GET['code'] ) ) : '';
+		if ( empty( $code ) ) {
+			cf7_smtp_log( 'OAuth2 callback: Missing or invalid authorization code' );
+			\set_transient( 'cf7_smtp_oauth2_error', \__( 'Missing or invalid authorization code. Please try again.', 'cf7-smtp' ), 60 );
+			\wp_safe_redirect( \admin_url( 'admin.php?page=cf7-smtp' ) );
+			exit;
 		}
 
 		try {
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$result = $handler->handle_callback( \sanitize_text_field( \wp_unslash( $_GET['code'] ) ), $state );
+			$result = $handler->handle_callback( $code, $state );
 
 			if ( $result['success'] ) {
 				\set_transient( 'cf7_smtp_oauth2_notice', $result['message'], 60 );

--- a/backend/Settings_Page.php
+++ b/backend/Settings_Page.php
@@ -114,17 +114,19 @@ class Settings_Page extends Base {
 			return;
 		}
 
-		// Verify nonce for OAuth2 callback.
-		if ( ! isset( $_GET['state'] ) || ! \wp_verify_nonce( \sanitize_key( $_GET['state'] ), 'cf7-smtp-oauth2' ) ) {
-			cf7_smtp_log( 'OAuth2 callback: Invalid nonce or missing state parameter' );
+		$handler = new \cf7_smtp\Core\OAuth2_Handler();
+		$state   = isset( $_GET['state'] ) ? \sanitize_text_field( \wp_unslash( $_GET['state'] ) ) : '';
+
+		// Verify state for OAuth2 callback using transient-based validation.
+		if ( empty( $state ) || ! $handler->validate_state( $state, false ) ) {
+			cf7_smtp_log( 'OAuth2 callback: Invalid state parameter or missing state' );
 			return;
 		}
 
 		// Handle OAuth2 error responses (e.g. user cancelled the Microsoft consent screen).
-		// This check MUST come after state verification to prevent forged error notices.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- state/nonce already verified above
-		if ( isset( $_GET['error'] ) ) {
-			$error_code = \sanitize_text_field( \wp_unslash( $_GET['error'] ) );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- state/transient already verified above
+		if ( isset( $_GET['error'] ) || isset( $_GET['error_description'] ) ) {
+			$error_code = isset( $_GET['error'] ) ? \sanitize_text_field( \wp_unslash( $_GET['error'] ) ) : 'unknown_error';
 			$error_desc = isset( $_GET['error_description'] )
 				? \sanitize_text_field( \wp_unslash( $_GET['error_description'] ) )
 				: '';
@@ -148,9 +150,8 @@ class Settings_Page extends Base {
 		}
 
 		try {
-			$handler = new \cf7_smtp\Core\OAuth2_Handler();
 			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$result = $handler->handle_callback( \sanitize_text_field( \wp_unslash( $_GET['code'] ) ), \sanitize_text_field( \wp_unslash( $_GET['state'] ) ) );
+			$result = $handler->handle_callback( \sanitize_text_field( \wp_unslash( $_GET['code'] ) ), $state );
 
 			if ( $result['success'] ) {
 				\set_transient( 'cf7_smtp_oauth2_notice', $result['message'], 60 );

--- a/cf7-smtp.php
+++ b/cf7-smtp.php
@@ -8,7 +8,7 @@
  * Description:     A trustworthy SMTP plugin for Contact Form 7. Simple and useful.
  * Version:         1.1.0
  * Author:          codekraft
- * Contributors:    gardenboi
+ * Contributors:    gardenboi, MemoryShadow
  * Author URI:      https://modul-r.codekraft.it/
  * Text Domain:     cf7-smtp
  * License:         GPL 2.0+

--- a/core/OAuth2_Handler.php
+++ b/core/OAuth2_Handler.php
@@ -57,7 +57,7 @@ class OAuth2_Handler extends Base {
 				'scopes'                       => array( 'https://outlook.office.com/SMTP.Send', 'offline_access' ),
 				'auth_url'                     => 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
 				'token_url'                    => 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
-				'redirect_uri'                 => admin_url( 'admin.php?page=cf7-smtp&oauth2_callback=1' ),
+				'redirect_uri'                 => rest_url( 'cf7-smtp/v1/oauth2/callback' ),
 			),
 		);
 	}

--- a/core/OAuth2_Handler.php
+++ b/core/OAuth2_Handler.php
@@ -308,7 +308,7 @@ class OAuth2_Handler extends Base {
 		$user_id      = get_current_user_id();
 		$stored_state = get_transient( 'cf7_smtp_oauth2_state_' . $user_id );
 
-		if ( empty( $stored_state ) || $state !== $stored_state ) {
+		if ( empty( $stored_state ) || ! hash_equals( $stored_state, $state ) ) {
 			return false;
 		}
 

--- a/core/OAuth2_Handler.php
+++ b/core/OAuth2_Handler.php
@@ -194,15 +194,18 @@ class OAuth2_Handler extends Base {
 			$options['prompt']      = 'consent';
 		}
 
-		// Use WP nonce as state for security and to satisfy Settings_Page verification
+		// Use WP nonce as state for security and to satisfy Settings_Page verification.
 		$options['state'] = wp_create_nonce( 'cf7-smtp-oauth2' );
 
 		$auth_url = $provider->getAuthorizationUrl( $options );
 		$state    = $provider->getState();
 
-		// Store state for verification.
-		set_transient( 'cf7_smtp_oauth2_state', $state, 10 * MINUTE_IN_SECONDS );
-		set_transient( 'cf7_smtp_oauth2_provider', $provider_key, 10 * MINUTE_IN_SECONDS );
+		// Scope transients to the current user to prevent state collisions when
+		// multiple admins initiate OAuth2 flows simultaneously (defence-in-depth;
+		// wp_verify_nonce already provides user-bound CSRF protection).
+		$user_id = get_current_user_id();
+		set_transient( 'cf7_smtp_oauth2_state_' . $user_id, $state, 10 * MINUTE_IN_SECONDS );
+		set_transient( 'cf7_smtp_oauth2_provider_' . $user_id, $provider_key, 10 * MINUTE_IN_SECONDS );
 
 		return $auth_url;
 	}
@@ -216,8 +219,9 @@ class OAuth2_Handler extends Base {
 	 * @return array{success: bool, message: string, email?: string}
 	 */
 	public function handle_callback( string $code, string $state ): array {
-		// Verify state.
-		$stored_state = get_transient( 'cf7_smtp_oauth2_state' );
+		// Read user-scoped transients (set by get_authorization_url for the same user).
+		$user_id      = get_current_user_id();
+		$stored_state = get_transient( 'cf7_smtp_oauth2_state_' . $user_id );
 		if ( empty( $stored_state ) || $state !== $stored_state ) {
 			return array(
 				'success' => false,
@@ -225,7 +229,7 @@ class OAuth2_Handler extends Base {
 			);
 		}
 
-		$provider_key = get_transient( 'cf7_smtp_oauth2_provider' );
+		$provider_key = get_transient( 'cf7_smtp_oauth2_provider_' . $user_id );
 		if ( empty( $provider_key ) ) {
 			return array(
 				'success' => false,
@@ -233,9 +237,9 @@ class OAuth2_Handler extends Base {
 			);
 		}
 
-		// Clean up transients.
-		delete_transient( 'cf7_smtp_oauth2_state' );
-		delete_transient( 'cf7_smtp_oauth2_provider' );
+		// Clean up user-scoped transients immediately after reading.
+		delete_transient( 'cf7_smtp_oauth2_state_' . $user_id );
+		delete_transient( 'cf7_smtp_oauth2_provider_' . $user_id );
 
 		$provider = $this->create_provider( $provider_key );
 		if ( ! $provider ) {

--- a/core/OAuth2_Handler.php
+++ b/core/OAuth2_Handler.php
@@ -219,16 +219,15 @@ class OAuth2_Handler extends Base {
 	 * @return array{success: bool, message: string, email?: string}
 	 */
 	public function handle_callback( string $code, string $state ): array {
-		// Read user-scoped transients (set by get_authorization_url for the same user).
-		$user_id      = get_current_user_id();
-		$stored_state = get_transient( 'cf7_smtp_oauth2_state_' . $user_id );
-		if ( empty( $stored_state ) || $state !== $stored_state ) {
+		// Verify state using the centralized validation method (consuming the state).
+		if ( ! $this->validate_state( $state, true ) ) {
 			return array(
 				'success' => false,
 				'message' => __( 'Invalid state parameter. Please try again.', 'cf7-smtp' ),
 			);
 		}
 
+		$user_id      = get_current_user_id();
 		$provider_key = get_transient( 'cf7_smtp_oauth2_provider_' . $user_id );
 		if ( empty( $provider_key ) ) {
 			return array(
@@ -237,8 +236,7 @@ class OAuth2_Handler extends Base {
 			);
 		}
 
-		// Clean up user-scoped transients immediately after reading.
-		delete_transient( 'cf7_smtp_oauth2_state_' . $user_id );
+		// Clean up provider transient after reading.
 		delete_transient( 'cf7_smtp_oauth2_provider_' . $user_id );
 
 		$provider = $this->create_provider( $provider_key );
@@ -296,6 +294,29 @@ class OAuth2_Handler extends Base {
 				),
 			);
 		}//end try
+	}
+
+	/**
+	 * Validate the OAuth2 state parameter against the stored transient.
+	 *
+	 * @param string $state   The state to validate.
+	 * @param bool   $consume Whether to delete the stored state after validation.
+	 *
+	 * @return bool True if the state is valid.
+	 */
+	public function validate_state( string $state, bool $consume = false ): bool {
+		$user_id      = get_current_user_id();
+		$stored_state = get_transient( 'cf7_smtp_oauth2_state_' . $user_id );
+
+		if ( empty( $stored_state ) || $state !== $stored_state ) {
+			return false;
+		}
+
+		if ( $consume ) {
+			delete_transient( 'cf7_smtp_oauth2_state_' . $user_id );
+		}
+
+		return true;
 	}
 
 	/**

--- a/rest/Api.php
+++ b/rest/Api.php
@@ -467,9 +467,13 @@ class Api extends Base {
 			'oauth2_callback' => 1,
 		);
 
-		$params = array( 'code', 'state', 'session_state' );
+		// Include error params so the admin handler can display user-friendly failure notices
+		// (e.g. error=access_denied when the user cancels the Microsoft consent screen).
+		$params = array( 'code', 'state', 'session_state', 'error', 'error_description' );
 		foreach ( $params as $param ) {
-			if ( isset( $request[ $param ] ) ) {
+			// Guard against array-type inputs (e.g. ?code[]=foo) that would cause a
+			// sanitize_text_field() warning and potentially a 500 error.
+			if ( isset( $request[ $param ] ) && is_scalar( $request[ $param ] ) ) {
 				$query_args[ $param ] = sanitize_text_field( $request[ $param ] );
 			}
 		}

--- a/rest/Api.php
+++ b/rest/Api.php
@@ -174,6 +174,16 @@ class Api extends Base {
 
 		\register_rest_route(
 			'cf7-smtp/v1',
+			'/oauth2/callback',
+			array(
+				'methods'             => 'GET',
+				'permission_callback' => '__return_true',
+				'callback'            => array( $this, 'oauth2_callback_redirect' ),
+			)
+		);
+
+		\register_rest_route(
+			'cf7-smtp/v1',
 			'/check-dns/',
 			array(
 				'methods'             => 'POST',
@@ -442,6 +452,31 @@ class Api extends Base {
 				'message' => 'Logs flushed',
 			)
 		);
+	}
+
+	/**
+	 * OAuth2 callback redirect endpoint.
+	 * Receives the code and state from the provider and redirects to the admin page.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return void
+	 */
+	public function oauth2_callback_redirect( $request ) {
+		$query_args = array(
+			'page'            => 'cf7-smtp',
+			'oauth2_callback' => 1,
+		);
+
+		$params = array( 'code', 'state', 'session_state' );
+		foreach ( $params as $param ) {
+			if ( isset( $request[ $param ] ) ) {
+				$query_args[ $param ] = sanitize_text_field( $request[ $param ] );
+			}
+		}
+
+		$redirect_url = add_query_arg( $query_args, admin_url( 'admin.php' ) );
+		wp_safe_redirect( $redirect_url );
+		exit;
 	}
 
 	/**

--- a/src/scripts/admin.ts
+++ b/src/scripts/admin.ts
@@ -249,6 +249,19 @@ export function smtpAdmin(): void {
 					providerRow.style.display = 'none';
 				}
 			}
+
+			const redirectUriEl = document.getElementById(
+				'cf7_smtp_oauth2_redirect_uri'
+			) as HTMLElement | null;
+			if (redirectUriEl) {
+				const redirectUri =
+					method === 'gmail'
+						? redirectUriEl.dataset.gmailRedirectUri
+						: redirectUriEl.dataset.office365RedirectUri;
+				if (redirectUri) {
+					redirectUriEl.textContent = redirectUri;
+				}
+			}
 		}
 	};
 


### PR DESCRIPTION
This pull request has fixed the following issues:

Currently, Microsoft does not allow the provision of URLs with query parameters in the Web type callback URL.

Therefore, the current `https://wordpress.site.host/wp-admin/admin.php?page=cf7-smtp&oauth2_callback=1` format URL cannot be properly configured.

When using Outlook as the target mail service, The target URL for redirection is changed to the following format: `https://wordpress.site.host/index.php/wp-json/cf7-smtp/v1/oauth2/callback`

To facilitate the future maintenance of a single long-term redirection processing logic, the new implementation method for redirection URLs is as follows: Redirection URLs without request parameters will be redirected again to the old version's request format.

Ref: #43