### PR TITLE
1.1.1 - pre-release fixes

### DIFF
--- a/engine/Context.php
+++ b/engine/Context.php
@@ -70,7 +70,7 @@ class Context {
 	 * @param WP_User|null $user The given user.
 	 * @return bool
 	 */
-	public static function is_user_admin( WP_User $user = null ): bool
+	public static function is_user_admin( ?WP_User $user = null ): bool
 	{ // phpcs:ignore
 		if ( \is_null( $user ) ) {
 			$user = \wp_get_current_user();


### PR DESCRIPTION
#### compat
update `is_user_admin` method to allow nullable `WP_User` parameter (PHP 8.5)